### PR TITLE
feat(transform): add support for after() hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ts-codemod
+
 [![Build Status](https://travis-ci.com/tusharmath/ts-codemod.svg?branch=master)](https://travis-ci.com/tusharmath/ts-codemod)
 ![npm](https://img.shields.io/npm/v/ts-codemod.svg)
-
 
 Code-Modifier for Typescript based projects.
 
@@ -110,8 +110,15 @@ To pass custom params to your transformation can be done as follows —
 export type MyParams = {
   moduleName: string
 }
+
 // my-custom-transformation.ts
 export default class MyCustomTransformation extends Transformation<MyParams> {
+
+  // Called before the transformation is applied on the file
+  before () {
+
+  }
+
   apply(node: ts.Node): ts.VisitResult<ts.Node> {
 
 
@@ -119,6 +126,11 @@ export default class MyCustomTransformation extends Transformation<MyParams> {
     console.log(this.params.moduleName)
 
     ...
+  }
+
+  // Called after the transformation is applied on the file
+  after () {
+
   }
 }
 ```

--- a/src/Transformation.ts
+++ b/src/Transformation.ts
@@ -1,6 +1,6 @@
 import * as ts from 'typescript'
-import {SCRIPT_TARGET} from './script-target'
 import {eqNode} from './eq-node'
+import {SCRIPT_TARGET} from './script-target'
 
 export abstract class Transformation<T = {}> {
   constructor(
@@ -9,7 +9,9 @@ export abstract class Transformation<T = {}> {
     readonly params: T
   ) {}
 
-  init() {}
+  before() {}
+
+  after() {}
 
   abstract visit(node: ts.Node): ts.VisitResult<ts.Node>
 

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,7 +1,7 @@
-import * as ts from 'typescript'
 import {curry2} from 'ts-curry'
-import {SCRIPT_TARGET} from './script-target'
+import * as ts from 'typescript'
 import {Transformation} from '..'
+import {SCRIPT_TARGET} from './script-target'
 const debug = require('debug')('ts-codemod')
 
 export interface TransformationCtor<Params = {}> {
@@ -36,10 +36,13 @@ export function transform<Params>(
   const transformed = ts.transform(sourceFile, [
     curry2((context: ts.TransformationContext, file: ts.SourceFile) => {
       const transformer = new o.transformationCtor(o.path, context, o.params)
-      transformer.init()
+      transformer.before()
       debug(`PARAMS:`, o.params)
       debug(`FILE: ${o.path}`)
-      return transformer.forEach(file) as ts.SourceFile
+      const transformedFile = transformer.forEach(file) as ts.SourceFile
+
+      transformer.after()
+      return transformedFile
     })
   ])
   const printer = ts.createPrinter({newLine: ts.NewLineKind.LineFeed})

--- a/transformations/replace-node.ts
+++ b/transformations/replace-node.ts
@@ -11,7 +11,7 @@ export default class ReplaceNode extends Transformation<{
   private matchWith: ts.Node = ts.createEmptyStatement()
   private replaceWith: ts.Node = ts.createEmptyStatement()
 
-  init() {
+  before() {
     const {matchWith, replaceWith} = this.params
     this.matchWith = this.toNode(matchWith)
     this.replaceWith = this.toNode(replaceWith)


### PR DESCRIPTION
added a new `after()` hook

BREAKING CHANGE: `init()` hook has been renamed to `before()` hook.

fix #3