### PR TITLE
fix(transformation): update crawler algorithm

### DIFF
--- a/src/Transformation.ts
+++ b/src/Transformation.ts
@@ -17,9 +17,14 @@ export abstract class Transformation<T = {}> {
 
   public forEach = (input: ts.Node): ts.VisitResult<ts.Node> => {
     const node = this.visit(input)
-    return node instanceof Array
-      ? node.map(_ => ts.visitEachChild(_, this.forEach, this.ctx))
-      : ts.visitEachChild(node, this.forEach, this.ctx)
+
+    if (node === input) {
+      return node instanceof Array
+        ? node.map(_ => ts.visitEachChild(_, this.forEach, this.ctx))
+        : ts.visitEachChild(node, this.forEach, this.ctx)
+    }
+
+    return node
   }
 
   public toNode(template: string): ts.Node {

--- a/test/replace-node.test.ts
+++ b/test/replace-node.test.ts
@@ -42,4 +42,25 @@ describe('replace-node', () => {
     }).newContent
     assert.strictEqual(actual, expected)
   })
+
+  it('should not fall into a loop if replaceWith contains a subset of matchWith', () => {
+    const input = normalize(`
+      function doAction (params) {
+        console.log(params.inputValue)
+      }
+    `)
+    const expected = normalize(`
+      function doAction (params) {
+        console.log(params && params.inputValue)
+      }
+    `)
+    
+    const actual = transform({
+      transformationCtor: ReplaceNode,
+      content: input,
+      path: './src/file.ts',
+      params: {matchWith: 'params.inputValue', replaceWith: 'params && params.inputValue'}
+    }).newContent
+    assert.strictEqual(actual, expected)
+  })
 })

--- a/transformations/replace-node.ts
+++ b/transformations/replace-node.ts
@@ -10,7 +10,6 @@ export default class ReplaceNode extends Transformation<{
 }> {
   private matchWith: ts.Node = ts.createEmptyStatement()
   private replaceWith: ts.Node = ts.createEmptyStatement()
-  private skipCount: number = 0
 
   public before(): void {
     const {matchWith, replaceWith} = this.params
@@ -22,15 +21,13 @@ export default class ReplaceNode extends Transformation<{
 
   public visit(node: ts.Node): ts.VisitResult<ts.Node> {
     debug('node:', cName(node), `'${node.getFullText()}'`)
-    debug(`skipCount: ${this.skipCount}`)
-    if (this.skipCount <= 0 && this.equal(node, this.matchWith)) {
+    if (this.equal(node, this.matchWith)) {
       debug(
         'replacing',
         node.getFullText(),
         'with',
         this.replaceWith.getFullText()
       )
-      this.skipCount = this.replaceWith.getChildren().length
       return this.replaceWith
     }
     return node

--- a/transformations/replace-node.ts
+++ b/transformations/replace-node.ts
@@ -10,6 +10,7 @@ export default class ReplaceNode extends Transformation<{
 }> {
   private matchWith: ts.Node = ts.createEmptyStatement()
   private replaceWith: ts.Node = ts.createEmptyStatement()
+  private skipCount: number = 0
 
   public before(): void {
     const {matchWith, replaceWith} = this.params
@@ -21,13 +22,15 @@ export default class ReplaceNode extends Transformation<{
 
   public visit(node: ts.Node): ts.VisitResult<ts.Node> {
     debug('node:', cName(node), `'${node.getFullText()}'`)
-    if (this.equal(node, this.matchWith)) {
+    debug(`skipCount: ${this.skipCount}`)
+    if (this.skipCount <= 0 && this.equal(node, this.matchWith)) {
       debug(
         'replacing',
         node.getFullText(),
         'with',
         this.replaceWith.getFullText()
       )
+      this.skipCount = this.replaceWith.getChildren().length
       return this.replaceWith
     }
     return node


### PR DESCRIPTION
There was a bug in the builtin transformer `replace-node`. If the `replaceWith` contained a the value of `matchWith`, it would fall into an infinite loop and throw with `RangeError: Maximum call stack size exceeded`.